### PR TITLE
Update `package.json` repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "eslint-config-jquery"
+    "url": "jquery/eslint-config-jquery"
   },
   "homepage": "https://contribute.jquery.org/style-guide/js/",
   "issues": "https://github.com/jquery/eslint-config-jquery/issues",


### PR DESCRIPTION
The repo URL needs to be prefixed with the GitHub username, i.e. `jquery/eslint-config-jquery`

This can also be tested by running `npm repo` from a terminal prompt inside this repo folder, it should open the default browser to https://github.com/jquery/eslint-config-jquery/

See https://docs.npmjs.com/all#repository