### PR TITLE
max-len uses ignoreUrls and ignoreRegExpLiterals options

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,7 +64,9 @@
 			"error",
 			{
 				"code": 100,
-				"ignoreComments": true
+				"ignoreComments": true,
+				"ignoreUrls": true,
+				"ignoreRegExpLiterals": true
 			}
 		],
 		"no-mixed-spaces-and-tabs": "error",


### PR DESCRIPTION
Per the [spacing section](https://contribute.jquery.org/style-guide/js/#spacing) of the jQuery style guide:

> * Lines should be no longer than 80 characters, and must not exceed 100 (counting tabs as 4 spaces). There are 2 exceptions, both allowing the line to exceed 100 characters:
>     * If the line contains a comment with a long URL.
>     * If the line contains a regex literal. This prevents having to use the regex constructor which requires otherwise unnecessary string escaping.

Both of the exceptions above are represented by the new options I have added to the rule configuration for ESLint's `max-len` rule.