### PR TITLE
Enable no-unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,13 @@
 			"double"
 		],
 		"no-undef": "error",
-		"no-unused-vars": "error",
+		"no-unused-vars": [
+			"error",
+			{
+				"args":  "all",
+				"argsIgnorePattern": "^_"
+			}
+		],
 		"operator-linebreak": [
 			"error",
 			"after"


### PR DESCRIPTION
Please review @jquery/core @Krinkle @trentmwillis @leobalter

This rule requires all function parameters to be used, not just the last one.
In cases where that's not possible as we need to match an external API, there's
an escape hatch of prefixing an unused argument with _.

This change makes it easier to catch unused AMD dependencies and unused
parameters in internal functions the API of which we may change at will, among
other things.

Ref jquery/jquery#4381