### PR TITLE
Enable no-extra-semi & no-irregular-whitespace

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -77,6 +77,7 @@
 		],
 		"no-mixed-spaces-and-tabs": "error",
 		"no-trailing-spaces": "error",
+		"no-irregular-whitespace": "error",
 		"no-multi-str": "error",
 		"comma-dangle": [
 			"error",
@@ -112,6 +113,7 @@
 				"after": true
 			}
 		],
+		"no-extra-semi": "error",
 		"space-infix-ops": "error",
 		"eol-last": "error",
 		"lines-around-comment": [


### PR DESCRIPTION
The no-extra-semi rule:
https://eslint.org/docs/rules/no-extra-semi
disallows unnecessary semicolons, e.g. it forbids the following:
```js
var x = 5;;

function foo() {
    // code
};
```

In jQuery we usually don't add a semicolon at the end of function declarations
but I found a few cases where we do, creating an inconsistency.

The no-irregular-whitespace rule:
https://eslint.org/docs/rules/no-irregular-whitespace
forbids most whitespaces that may be hard to notice in source. We have one such
occurrence in Core code that would be good to forbid.

Fixes #15

cc @jquery/core @krinkle @leobalter